### PR TITLE
Add missing `image_url` and `image_tag` filters

### DIFF
--- a/packages/specs/src/liquid/data/shopify/filters.ts
+++ b/packages/specs/src/liquid/data/shopify/filters.ts
@@ -493,6 +493,24 @@ export const Filters: IFilters = {
       url: 'https://shopify.dev/api/liquid/filters/additional-filters#json'
     }
   },
+  image_url: {
+    description: 'Returns the CDN URL for an image. Accepts an image size as a parameter.',
+    snippet: 'image_url: width: ${2:450}',
+    reference: {
+      name: 'Shopify Liquid',
+      url: 'https://shopify.dev/docs/api/liquid/filters/image_url'
+    }
+
+  },
+  image_tag: {
+    description: 'Generates an HTML <img> tag for a given image_url',
+    snippet: 'image_tag',
+    reference: {
+      name: 'Shopify Liquid',
+      url: 'https://shopify.dev/docs/api/liquid/filters/image_tag'
+    }
+
+  },
   img_tag: {
     description: 'Generates an image tag.',
     reference: {


### PR DESCRIPTION
As I was working today I noticed the `image_url` filter had no completion.

I suspect I've not done all that's required to complete this PR. I tried to follow the contributing guidelines but got a bunch of errors when running `pnpm build` - even when I only ran it on the `specs` package. I'm in a hurry tonight so frustratingly I don't have time to work them out. If anything else needs to be done feel free to complete the steps, or I can look into it over the weekend.